### PR TITLE
Refactor custom components to be render functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ import InstaStory from 'react-native-insta-story';
 | onStart                | Todo when start                                     | function  |     null      |
 | duration               | Per story duration seconds                          | number    |      10       |
 | swipeText              | Text of swipe component                             | string    |   Swipe Up    |
-| customSwipeUpComponent | For use custom component for swipe area             | component |               |
-| customCloseComponent   | For use custom component for close button           | component |               |
+| renderSwipeUpComponent | Render a custom swipe up component                  | function  |               |
+| renderCloseComponent   | Render a custom close button                        | function  |               |
+| renderTextComponent    | Render custom avatar text component                 | function  |               |
 | avatarSize             | Size of avatar circle                               | number    |      60       |
 | showAvatarText         | For show or hide avatar text.                       | bool      |     true      |
 | textStyle              | For avatar text style                               | TextStyle |               |
 
 ## Usage
+
+### Basic
 
 ```javascript
 const data = [
@@ -100,11 +103,37 @@ const data = [
   duration={10}
   onStart={(item) => console.log(item)}
   onClose={(item) => console.log('close: ', item)}
-  customSwipeUpComponent={
-    <View>
-      <Text>Swipe</Text>
+  style={{ marginTop: 30 }}
+/>;
+```
+
+### Custom components
+
+The render component functions are all passed `item` as a prop which is the current [IUserStoryItem](./src/interfaces/index.ts#L15) being displayed.
+
+`renderSwipeUpComponent` and `renderCloseComponent` are both passed the `onPress` prop which is a function that closes the current story item modal and calls the `IUserStoryItem.onPress` function. `onPress` is passed so you could add other buttons. This is useful when adding a button which has it's own `onPress` prop, eg. a share button, next to the close button.
+
+`renderTextComponent` is passed the `profileName` of the current story's user.
+
+```javascript
+const data = [...sameDataAsBasicExampleAbove];
+<InstaStory
+  data={data}
+  duration={10}
+  onStart={(item) => console.log(item)}
+  onClose={(item) => console.log('close: ', item)}
+  renderCloseComponent={({ item, onPress }) => (
+    <View style={{ flexDirection: 'row' }}>
+      <Button onPress={shareStory}>Share</Button>
+      <Button onPress={onPress}>X</Button>
     </View>
-  }
+  )}
+  renderTextComponent={({ item, profileName }) => (
+    <View>
+      <Text>{profileName}</Text>
+      <Text>{item.customProps?.yourCustomProp}</Text>
+    </View>
+  )}
   style={{ marginTop: 30 }}
 />;
 ```

--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -18,11 +18,12 @@ export const Story = ({
   onClose,
   duration,
   swipeText,
-  customSwipeUpComponent,
-  customCloseComponent,
   avatarSize,
   showAvatarText,
   avatarTextStyle,
+  renderCloseComponent,
+  renderSwipeUpComponent,
+  renderTextComponent,
 }: StoryProps) => {
   const [dataState, setDataState] = useState<IUserStory[]>(data);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -101,8 +102,9 @@ export const Story = ({
           currentPage={currentPage}
           onFinish={onStoryFinish}
           swipeText={swipeText}
-          customSwipeUpComponent={customSwipeUpComponent}
-          customCloseComponent={customCloseComponent}
+          renderSwipeUpComponent={renderSwipeUpComponent}
+          renderCloseComponent={renderCloseComponent}
+          renderTextComponent={renderTextComponent}
           onClosePress={() => {
             setIsModalOpen(false);
             if (onClose) {

--- a/src/StoryListItem.tsx
+++ b/src/StoryListItem.tsx
@@ -11,7 +11,6 @@ import {
   View,
   Platform,
   SafeAreaView,
-  PanResponderGestureState,
 } from 'react-native';
 import GestureRecognizer from 'react-native-swipe-gestures';
 
@@ -30,12 +29,13 @@ export const StoryListItem = ({
   profileImage,
   profileName,
   duration,
-  customCloseComponent,
-  customSwipeUpComponent,
   onFinish,
   onClosePress,
   stories,
   currentPage,
+  renderCloseComponent,
+  renderSwipeUpComponent,
+  renderTextComponent,
   ...props
 }: StoryListItemProps) => {
   const [load, setLoad] = useState<boolean>(true);
@@ -223,23 +223,33 @@ export const StoryListItem = ({
         <View style={styles.userContainer}>
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <Image style={styles.avatarImage} source={{ uri: profileImage }} />
-            <Text style={styles.avatarText}>{profileName}</Text>
+            {typeof renderTextComponent === 'function' ? (
+              renderTextComponent({
+                item: content[current],
+                profileName,
+              })
+            ) : (
+              <Text style={styles.avatarText}>{profileName}</Text>
+            )}
           </View>
-          <TouchableOpacity
-            onPress={() => {
-              if (onClosePress) {
-                onClosePress();
-              }
-            }}
-          >
-            <View style={styles.closeIconContainer}>
-              {customCloseComponent ? (
-                customCloseComponent
-              ) : (
+          <View style={styles.closeIconContainer}>
+            {typeof renderCloseComponent === 'function' ? (
+              renderCloseComponent({
+                onPress: onClosePress,
+                item: content[current],
+              })
+            ) : (
+              <TouchableOpacity
+                onPress={() => {
+                  if (onClosePress) {
+                    onClosePress();
+                  }
+                }}
+              >
                 <Text style={{ color: 'white' }}>X</Text>
-              )}
-            </View>
-          </TouchableOpacity>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
         <View style={styles.pressContainer}>
           <TouchableWithoutFeedback
@@ -274,20 +284,19 @@ export const StoryListItem = ({
           </TouchableWithoutFeedback>
         </View>
       </View>
-      {content[current].onPress && (
+      {typeof renderSwipeUpComponent === 'function' ? (
+        renderSwipeUpComponent({
+          onPress: onSwipeUp,
+          item: content[current],
+        })
+      ) : (
         <TouchableOpacity
           activeOpacity={1}
           onPress={onSwipeUp}
           style={styles.swipeUpBtn}
         >
-          {customSwipeUpComponent ? (
-            customSwipeUpComponent
-          ) : (
-            <>
-              <Text style={{ color: 'white', marginTop: 5 }}></Text>
-              <Text style={{ color: 'white', marginTop: 5 }}>{swipeText}</Text>
-            </>
-          )}
+          <Text style={{ color: 'white', marginTop: 5 }}></Text>
+          <Text style={{ color: 'white', marginTop: 5 }}>{swipeText}</Text>
         </TouchableOpacity>
       )}
     </GestureRecognizer>

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,24 +3,42 @@ import { ColorValue, ImageStyle, TextStyle, ViewStyle } from 'react-native';
 
 export type NextOrPrevious = 'next' | 'previous';
 
-export interface IUserStory {
+export interface IUserStory<T = Record<string, any>> {
   user_id: number;
   user_image: string | undefined;
   user_name: string;
-  stories: IUserStoryItem[];
+  stories: IUserStoryItem<T>[];
   /** INTERNAL USE ONLY */
   seen?: boolean;
 }
 
-export interface IUserStoryItem {
+export interface IUserStoryItem<T = Record<string, any>> {
   story_id: number;
   story_image: string | undefined;
   /** Function that gets called when the swipe up button is pressed */
   onPress?: (props?: any) => any;
   swipeText?: string;
+  /** Add your own custom props to access in the custom render methods */
+  customProps?: T;
   /** FOR INTERNAL USE ONLY */
   finish?: number;
 }
+
+export interface CustomButtonRenderProps<T = Record<string, any>> {
+  onPress: (props?: any) => any;
+  item: IUserStoryItem<T>;
+}
+
+export type RenderCustomButton<T = Record<string, any>> = (
+  props: CustomButtonRenderProps<T>,
+) => React.ReactNode;
+
+export interface TextRenderProps<T = Record<string, any>> {
+  profileName: string;
+  item: IUserStoryItem<T>;
+}
+
+export type RenderCustomText = (props: TextRenderProps) => React.ReactNode;
 
 interface SharedCircleListProps {
   handleStoryItemPress: (item: IUserStory, index?: number) => void;
@@ -56,10 +74,21 @@ export interface StoryListItemProps {
   duration: number;
   /** Text of the swipe up button */
   swipeText?: string;
-  /** A custom swipe up component */
-  customSwipeUpComponent?: ReactNode;
-  /** A custom close component */
-  customCloseComponent?: ReactNode;
+  /**
+   * Callback which returns a custom React Element to use as the
+   * swipeUpComponent. IUserStoryItem is passed as an arg.
+   */
+  renderSwipeUpComponent?: RenderCustomButton;
+  /**
+   * Callback which returns a custom React Element to use as the
+   * closeComponent. IUserStoryItem is passed as an arg.
+   */
+  renderCloseComponent?: RenderCustomButton;
+  /**
+   * Callback which returns a custom React Element to use as the textComponent.
+   * IUserStoryItem and username are passed as args.
+   */
+  renderTextComponent?: RenderCustomText;
   onFinish?: (props?: any) => any;
   onClosePress: (props?: any) => any;
   stories: IUserStoryItem[];
@@ -85,10 +114,22 @@ export interface StoryProps {
   onStart?: (props?: IUserStory) => any;
   /** Text of the swipe up button */
   swipeText?: string;
-  /** A custom swipe up component */
-  customSwipeUpComponent?: ReactNode;
-  /** A custom close component */
-  customCloseComponent?: ReactNode;
+  /**
+   * Callback which returns a custom React Element to use as the
+   * swipeUpComponent. IUserStoryItem is passed as an arg.
+   */
+  renderSwipeUpComponent?: RenderCustomButton;
+  /**
+   * Callback which returns a custom React Element to use as the
+   * closeComponent. IUserStoryItem is passed as an arg.
+   */
+  renderCloseComponent?: RenderCustomButton;
+  /**
+   * Callback which returns a custom React Element to use as the textComponent
+   * next to the small avatar on the story item page. IUserStoryItem and
+   * username are passed as args.
+   */
+  renderTextComponent?: RenderCustomText;
   /** Display username below avatars in FlatList */
   showAvatarText?: boolean;
   /** Username text style below the avatar */


### PR DESCRIPTION
### Reasons for changes

- Adding custom components by just passing a component as a prop (like customCloseComponent) is almost useless because then the only way to close the story is by swiping down from the top
- This way uses a system such like [react-native-tab-view's renderTabBar](https://github.com/satya164/react-native-tab-view/blob/cafe21c202ab4bd6015d706887c0e3373960ce49/src/TabView.tsx#L25-L27) function
- This allows passing the current `item` and `onPress` or `profileName` as props to the render functions so they can have access to the `onClosePress` function
- This is useful in situations where you want to add another button component next to the close/swipe button which has it's own `onPress` prop. For example adding a share story button next to the close button like so:
- adding `customProps` to the `IUserStoryItem` enables users to add their own props, which is then useful for rendering a custom text component, for example, say adding the age of a instagram story which can be rendered underneath the users profile name (like instagram)

<img width="70" alt="Screenshot 2022-11-22 at 16 39 52" src="https://user-images.githubusercontent.com/62890543/203356811-c1a22afb-71cf-4b22-b168-6592f47f1c18.png" >

### Summary of changes

- [x] add:
  - `renderSwipeUpComponent`
  - `renderCloseComponent`
  - `renderTextComponent`
- [x] add `IUserStoryItem.customProps`

### Important ⚠️

- This is a breaking change and should incur a major release versioning update
