### PR TITLE
Add `onStorySeen` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ import InstaStory from 'react-native-insta-story';
 | pressedBorderColor     | Pressed border color of profile circle              | color     |     grey      |
 | onClose                | Todo when close                                     | function  |     null      |
 | onStart                | Todo when start                                     | function  |     null      |
+| onStorySeen            | Called each time story is seen                      | function  |     null      |
 | duration               | Per story duration seconds                          | number    |      10       |
 | swipeText              | Text of swipe component                             | string    |   Swipe Up    |
 | customSwipeUpComponent | For use custom component for swipe area             | component |               |
@@ -50,6 +51,8 @@ import InstaStory from 'react-native-insta-story';
 ## Usage
 
 ```javascript
+import InstaStory from 'react-native-insta-story';
+
 const data = [
   {
     user_id: 1,
@@ -95,11 +98,35 @@ const data = [
   },
 ];
 
+const [seenStories, setSeenStories] = useState(new Set());
+const updateSeenStories = ({ story: { story_id } }) => {
+  setSeenStories((prevSet) => {
+    prevSet.add(storyId);
+    return prevSet;
+  });
+};
+
+const handleSeenStories = async (item) => {
+  console.log(item);
+  const storyIds = [];
+  seenStories.forEach((storyId) => {
+    if (storyId) storyIds.push(storyId);
+  });
+  if (storyIds.length > 0) {
+    await fetch('myApi', {
+      method: 'POST',
+      body: JSON.stringify({ storyIds }),
+    });
+    seenStories.clear();
+  }
+};
+
 <InstaStory
   data={data}
   duration={10}
   onStart={(item) => console.log(item)}
-  onClose={(item) => console.log('close: ', item)}
+  onClose={handleSeenStories}
+  onStorySeen={updateSeenStories}
   customSwipeUpComponent={
     <View>
       <Text>Swipe</Text>

--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -23,12 +23,13 @@ export const Story = ({
   avatarSize,
   showAvatarText,
   avatarTextStyle,
+  onStorySeen,
 }: StoryProps) => {
   const [dataState, setDataState] = useState<IUserStory[]>(data);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [selectedData, setSelectedData] = useState<IUserStory[]>([]);
-  const cube = useRef<any>();
+  const cube = useRef<CubeNavigationHorizontal | AndroidCubeEffect>();
 
   // Component Functions
   const _handleStoryItemPress = (item: IUserStory, index?: number) => {
@@ -95,6 +96,7 @@ export const Story = ({
         <StoryListItem
           duration={duration * 1000}
           key={i}
+          userId={x.user_id}
           profileName={x.user_name}
           profileImage={x.user_image}
           stories={x.stories}
@@ -110,6 +112,7 @@ export const Story = ({
             }
           }}
           index={i}
+          onStorySeen={onStorySeen}
         />
       );
     });
@@ -118,7 +121,7 @@ export const Story = ({
     if (Platform.OS == 'ios') {
       return (
         <CubeNavigationHorizontal
-          ref={cube}
+          ref={cube as React.LegacyRef<CubeNavigationHorizontal>}
           callBackAfterSwipe={(x: any) => {
             if (x != currentPage) {
               setCurrentPage(parseInt(x));
@@ -131,7 +134,7 @@ export const Story = ({
     } else {
       return (
         <AndroidCubeEffect
-          ref={cube}
+          ref={cube as React.LegacyRef<AndroidCubeEffect>}
           callBackAfterSwipe={(x: any) => {
             if (x != currentPage) {
               setCurrentPage(parseInt(x));

--- a/src/StoryListItem.tsx
+++ b/src/StoryListItem.tsx
@@ -27,6 +27,7 @@ const { width, height } = Dimensions.get('window');
 export const StoryListItem = ({
   index,
   key,
+  userId,
   profileImage,
   profileName,
   duration,
@@ -36,6 +37,7 @@ export const StoryListItem = ({
   onClosePress,
   stories,
   currentPage,
+  onStorySeen,
   ...props
 }: StoryListItemProps) => {
   const [load, setLoad] = useState<boolean>(true);
@@ -178,6 +180,17 @@ export const StoryListItem = ({
 
   const swipeText =
     content?.[current]?.swipeText || props.swipeText || 'Swipe Up';
+
+  React.useEffect(() => {
+    if (onStorySeen && currentPage === index) {
+      onStorySeen({
+        user_id: userId,
+        user_image: profileImage,
+        user_name: profileName,
+        story: content[current],
+      });
+    }
+  }, [currentPage, index, onStorySeen, current]);
 
   return (
     <GestureRecognizer

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -22,6 +22,11 @@ export interface IUserStoryItem {
   finish?: number;
 }
 
+/** User with one story representing the current story on screen */
+export interface IUserSingleStory extends Omit<IUserStory, 'stories'> {
+  story: IUserStoryItem;
+}
+
 interface SharedCircleListProps {
   handleStoryItemPress: (item: IUserStory, index?: number) => void;
   /** The color of the avatar border when unseen */
@@ -46,8 +51,11 @@ export interface StoryCircleListItemProps extends SharedCircleListProps {
 
 // TODO: add JSDoc comments where necessary
 export interface StoryListItemProps {
+  /** Index of story  */
   index: number;
   key: number;
+  /** ID of the user - IUserStory.user_id */
+  userId: number;
   /** Name of the user - IUserStory.user_name */
   profileName: string;
   /** Profile picture of the user - IUserStory.user_image */
@@ -62,6 +70,11 @@ export interface StoryListItemProps {
   customCloseComponent?: ReactNode;
   onFinish?: (props?: any) => any;
   onClosePress: (props?: any) => any;
+  /**
+   * Function which will get called every time a story is seen. Will be called
+   * every time the user swipes backwards and forwards to that screen.
+   */
+  onStorySeen?: (userStory: IUserSingleStory) => any;
   stories: IUserStoryItem[];
   currentPage: number;
 }
@@ -83,6 +96,11 @@ export interface StoryProps {
   onClose?: (props?: IUserStory) => any;
   /** Called when story item is loaded */
   onStart?: (props?: IUserStory) => any;
+  /**
+   * Function which will get called every time a story is seen. Will be called
+   * every time the user swipes backwards and forwards to that screen.
+   */
+  onStorySeen?: (userStory: IUserSingleStory) => any;
   /** Text of the swipe up button */
   swipeText?: string;
   /** A custom swipe up component */


### PR DESCRIPTION
### Reasons for changes

- https://github.com/caglardurmus/react-native-insta-story/issues/42
- https://github.com/caglardurmus/react-native-insta-story/issues/28

### Summary of changes

- Add `onStorySeen` prop to `<Story />` which is called as a useEffect when the current item is on screen and `onStoryScreen` prop is passed
- Update `README` with  `onStorySeen` example which updates a Set of `story_id`s to be used in conjunction with the `onClose` prop
- Pass `userId` to `<StoryListItem />`
- Add type to `ref`
- Add `IUserSingleStory` interface
- Update some JSDoc comments
