### PR TITLE
defaultProps is no longer recommended

### DIFF
--- a/src/StoryListItem.tsx
+++ b/src/StoryListItem.tsx
@@ -29,7 +29,7 @@ export const StoryListItem = ({
   userId,
   profileImage,
   profileName,
-  duration,
+  duration = 10000,
   onFinish,
   onClosePress,
   stories,
@@ -333,9 +333,6 @@ export const StoryListItem = ({
 
 export default StoryListItem;
 
-StoryListItem.defaultProps = {
-  duration: 10000,
-};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
In React Native, using defaultProps is no longer recommended and will soon be completely removed. Instead, we need to use JavaScript's default parameter property.