### PR TITLE
Update Story.tsx defaultProps is no longer recommended

### DIFF
--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -23,7 +23,7 @@ export const Story = ({
   duration,
   swipeText,
   avatarSize,
-  showAvatarText,
+  showAvatarText = true,
   avatarTextStyle,
   onStorySeen,
   renderCloseComponent,
@@ -213,7 +213,3 @@ const styles = StyleSheet.create({
 });
 
 export default Story;
-
-Story.defaultProps = {
-  showAvatarText: true,
-};


### PR DESCRIPTION
In React Native, using defaultProps is no longer recommended and will soon be completely removed. Instead, we need to use JavaScript's default parameter property. 